### PR TITLE
Improved Writing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 
 __Cube.js is an open source modular framework to build analytical web applications__. It is primarily used to build internal business intelligence tools or to add customer-facing analytics to an existing application.
 
-Cube.js was designed to work with Serverless Query Engines like AWS Athena and Google BigQuery. Multi-stage querying approach makes it suitable for handling trillions of data points. Most modern RDBMS work with Cube.js as well and can be tuned for adequate performance.
+Cube.js was designed to work with Serverless Query Engines like AWS Athena and Google BigQuery. Multi-stage querying approach makes it suitable for handling trillions of data points. Most modern relational database management systems (RDBMS) work with Cube.js as well and can be tuned for adequate performance.
 
-Unlike others, it is not a monolith application, but a set of modules, which does one thing well. Cube.js provides modules to run transformations and modeling in data warehouse, querying and caching, managing API gateway and building UI on top of that.
+Cube.js is not a monolith application but a set of modules which run transformations and modeling in data warehouse, querying and caching, managing API gateway and building a user interface (UI).”
 
 ### Cube.js Backend
 
 - __Cube.js Schema.__ It acts as an ORM for analytics and allows to model everything from simple counts to cohort retention and funnel analysis.
-- __Cube.js Query Orchestration and Cache.__ It optimizes query execution by breaking queries into small, fast, reusable and materialzed pieces.
+- __Cube.js Query Orchestration and Cache.__ It optimizes query execution by breaking queries into small, fast, reusable and materialized pieces.
 - __Cube.js API Gateway.__ It provides idempotent long polling API which guarantees analytic query results delivery without request time frame limitations and tolerant to connectivity issues.
 
 ### Cube.js Frontend
@@ -27,11 +27,11 @@ Unlike others, it is not a monolith application, but a set of modules, which doe
 
 If you are building your own business intelligence tool or customer-facing analytics most probably you'll face the following problems:
 
-1. __Performance.__ Most of effort time in modern analytics software development is spent to provide adequate time to insight. In the world where every company data is a big data writing just SQL query to get insight isn't enough anymore.
-2. __SQL code organization.__ Modelling even a dozen of metrics with a dozen of dimensions using pure SQL queries sooner or later becomes a maintenance nightmare which ends up in building modelling framework.
+1. __Performance.__ Modern analytics software development provides adequate time to insight. Writing an SQL query does not provide enough insight for big data.
+2. __SQL code organization.__ Modelling a dozen metrics with a dozen dimensions using SQL queries becomes difficult to maintain resulting in building a modelling framework.
 3. __Infrastructure.__ Key components every production-ready analytics solution requires: analytic SQL generation, query results caching and execution orchestration, data pre-aggregation, security, API for query results fetch, and visualization.
 
-Cube.js has necessary infrastructure for every analytic application that heavily relies on its caching and pre-aggregation layer to provide several minutes raw data to insight delay and sub second API response times on a trillion of data points scale.
+Cube.js has the infrastructure for analytic applications that rely on its caching and pre-aggregation layer. These layers provide raw data to insight delay and API response times on a scale of a trillion data points.”
 
 ![](https://raw.githubusercontent.com/statsbotco/cube.js/master/docs/old-was-vs-cubejs-way.png)
 
@@ -262,7 +262,7 @@ If you have any questions or need help - [please join our Slack community](https
 ## Architecture
 __Cube.js acts as an analytics backend__, translating business logic (metrics and dimensions) into SQL and handling database connection. 
 
-The Cube.js javascript Client performs queries, expressed via dimensions, measures, and filters. The Server uses Cube.js Schema to generate a SQL code, which is executed by your database. The Server handles all the database connection, as well as pre-aggregations and caching layers. The result then sent back to the Client. The Client itself is visualization agnostic and works well with any chart library.
+The Cube.js javascript Client performs queries, expressed via dimensions, measures, and filters. The Server uses Cube.js Schema to generate a SQL code, which is executed by your database. The Server handles all the database connection, as well as pre-aggregations and caching layers. The result is sent back to the Client. The Client itself is visualization agnostic and works well with any chart library.
 
 <p align="center"><img src="https://i.imgur.com/FluGFqo.png" alt="Cube.js" width="100%"></p>
 


### PR DESCRIPTION
The first edit corrects the use of abbreviations. The first time an abbreviation is mentioned, the full name must accompany the abbreviation. After the first instance, the abbreviation can be used in place of the full name. In this case, the full name of “RDBMS” is “relational database management systems” and is accompanying the first use of the abbreviation.

The second edit adds concision. There is no need to state “Unlike others” when other applications have not been mentioned earlier. Removing the statement and combining the two sentences together creates a tighter sentence that does lose significance compared to the original.

The third edit corrects a spelling mistake. The author misspelled “materialized” as “materialzed.”

The fourth edit improves the concision and structure of the sentence. There were empty words that took an adequate amount of space in the sentence. Phrases like “Most of effort time” and “In the world where every company…” were not necessary and were wrote awkwardly. Removing the empty words creates a much better sentence that it easier to read and understand.

The fifth edit adds concision. The author wrote many phrases that can be rewritten as a word or two. Empty words take unnecessary space in the sentence and not adding significance to the sentence. Removing words was important but adding words was needed to make the last sentence cohesive.

The sixth edit eliminates a run-on sentence. The original is sentence is long and can be broken into two, concise sentences. By breaking the sentence into two parts, the reader can understand the information efficiently without having to recall what was said in the earlier part of the sentence.

The seventh edit is a grammar mistake. The author did not write “is” in the sentence “The result then sent back to the Client.” Once the “is” is inserted and “then” is removed, the sentence is understandable.

